### PR TITLE
Fix ref to taskDefinition in describe_task_definition response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed reference to taskDefinition in describe_task_definition response [#5](https://github.com/azavea/django-ecsmanage/pull/5)
 
 ## [0.1.0] - 2019-04-10
 ### Added
-- Update PyPi credentials [\#4](https://github.com/azavea/django-ecsmanage/pull/4)
-- Initialize Django module for one-off management commands [\#2](https://github.com/azavea/django-ecsmanage/pull/2)
+- Update PyPi credentials [#4](https://github.com/azavea/django-ecsmanage/pull/4)
+- Initialize Django module for one-off management commands [#2](https://github.com/azavea/django-ecsmanage/pull/2)
 
-[Unreleased]: https://github.com/azavea/django-ecsmanage/compare/0.1.0...HEAD
+[unreleased]: https://github.com/azavea/django-ecsmanage/compare/0.1.0...HEAD
 [0.1.0]: https://github.com/azavea/django-ecsmanage/releases/tag/0.1.0

--- a/ecsmanage/management/commands/ecsmanage.py
+++ b/ecsmanage/management/commands/ecsmanage.py
@@ -160,7 +160,9 @@ class Command(BaseCommand):
         """
         overrides = {"containerOverrides": [{"name": "django", "command": cmd}]}
 
-        task_def = self.ecs_client.describe_task_definition(taskDefinition=task_def_arn)
+        task_def = self.ecs_client.describe_task_definition(
+            taskDefinition=task_def_arn
+        )["taskDefinition"]
 
         # Only the awsvpc network mode supports the networkConfiguration
         # input value.


### PR DESCRIPTION
## Overview

The response for `describe_task_definition` contains several top-level keys, one of which is `taskDefinition`. In order to get task definition specific attributes (e.g., `networkMode`), the top-level `taskDefinition` key needs to be retrieved and assigned to `task_def`.

## Testing Instructions

Please use https://github.com/azavea/pwd-garp/pull/835 to test this PR.