### PR TITLE
Add Python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - DJANGO_SETTINGS_MODULE="settings_test"
 matrix:
   include:
+  - python: 2.7
   - python: 3.6
   # Workaround for Python 3.7 support. See:
   # https://github.com/travis-ci/travis-ci/issues/9815

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added Python 2.7 support [#6](https://github.com/azavea/django-ecsmanage/pull/6)
+
 ### Fixed
 - Fixed reference to taskDefinition in describe_task_definition response [#5](https://github.com/azavea/django-ecsmanage/pull/5)
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ the appropriate AWS resources for your cluster:
 ## Developing
 
 Local development is managed with Python virtual environments. Make sure that
-you have [Python 3.6+ and pip installed](https://www.python.org/downloads/)
+you have [Python 2.7+ and pip installed](https://www.python.org/downloads/)
 before starting.
 
 Install the development package in a virtual environment:

--- a/ecsmanage/management/commands/ecsmanage.py
+++ b/ecsmanage/management/commands/ecsmanage.py
@@ -1,3 +1,5 @@
+# -*- coding: future_fstrings -*-
+
 import boto3
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings

--- a/scripts/test
+++ b/scripts/test
@@ -27,7 +27,9 @@ function run_linters() {
 
     # Lint Python scripts.
     ./.venv/bin/flake8 --exclude ./*.pyc,./.venv
-    ./.venv/bin/black --check --target-version py36
+    if command -v ./.venv/bin/black > /dev/null; then
+        ./.venv/bin/black --check --target-version py36
+    fi
 }
 
 function run_tests() {

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,12 @@ setup(
     url="https://github.com/azavea/django-ecsmanage/",
     author="Azavea, Inc.",
     author_email="systems@azavea.com",
-    python_requires=">=3.6",
-    install_requires=["Django>=1.11, <=2.1", "boto3>=1.9.0"],
-    extras_require={"tests": ["flake8>=3.7.7", "black"]},
+    install_requires=[
+        "Django>=1.11, <=2.1",
+        "boto3>=1.9.0",
+        'future-fstrings>=1.0.0;python_version<"3.6"',
+    ],
+    extras_require={"tests": ["flake8>=3.7.7", 'black;python_version>"3.6"']},
     setup_requires=["setuptools_scm==3.*"],
     classifiers=[
         "Environment :: Web Environment",
@@ -34,6 +37,7 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Topic :: Internet :: WWW/HTTP",


### PR DESCRIPTION
## Overview

In order to support some of our legacy projects, add support for Python 2.7 to this module.

Most of the Python 2.7 support comes through support of `fstrings`. `fstrings` are supported by [`future-fstrings`](https://github.com/asottile/future-fstrings) via source file encoding cookies.

## Testing Instructions

Please use https://github.com/azavea/pwd-stormdrain-marking/pull/540 to test this PR.