### PR TITLE
Remove Python version constraint for future-fstrings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         "Django>=1.11, <=2.1",
         "boto3>=1.9.0",
-        'future-fstrings>=1.0.0;python_version<"3.6"',
+        "future-fstrings>=1.0.0",
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     extras_require={"tests": ["flake8>=3.7.7", 'black;python_version>"3.6"']},


### PR DESCRIPTION
## Overview

I tried to use this app in a Python 3.7 project. When I invoked the management command, Django threw:

```bash
  File "/usr/local/lib/python3.7/site-packages/ecsmanage/management/commands/ecsmanage.py", line 0
SyntaxError: unknown encoding: future_fstrings
```

It looks like this is because we add the encoding cookie to the top of the `ecsmanage.py` file, and Python 3.7 gets confused because `future_fstrings` has the version constraint `python_version<"3.6"`.

It should be fine to remove the version constraint all together, as `future_fstrings` will deactivate itself if it detects the Python interpreter supports f-strings natively:

https://github.com/asottile/future-fstrings/blob/83a7d57f90b4faed9135967c09da0f15d4ee8ec9/future_fstrings.py#L254-L265

This is related to https://github.com/asottile/future-fstrings/issues/11.

## Notes

I believe this failure on Python 3.7 means our test suite is lacking.

## Testing Instructions

See: https://github.com/open-apparel-registry/open-apparel-registry/pull/528