### PR TITLE
Use argparse.REMAINDER nargs value

### DIFF
--- a/ecsmanage/management/commands/ecsmanage.py
+++ b/ecsmanage/management/commands/ecsmanage.py
@@ -3,6 +3,7 @@
 import boto3
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
+from argparse import REMAINDER
 
 
 class Command(BaseCommand):
@@ -23,7 +24,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "cmd",
             type=str,
-            nargs="...",
+            nargs=REMAINDER,
             help="Command override for the ECS container (e.g. 'migrate')",
         )
 

--- a/ecsmanage/management/commands/ecsmanage.py
+++ b/ecsmanage/management/commands/ecsmanage.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "cmd",
             type=str,
-            nargs="+",
+            nargs="...",
             help="Command override for the ECS container (e.g. 'migrate')",
         )
 


### PR DESCRIPTION
## Overview

Right now, you cannot run commands with an argument (i.e. `--example-flag`) because ecsmanage tries to interpret the flag rather than pass it along. Substituting `+` for `...` gathers all the remaining command-line arguments into a list.

Resolves #8

## Testing Instructions

- Clone https://github.com/open-apparel-registry/open-apparel-registry
- Apply this diff:
```diff
diff --git a/src/django/Dockerfile b/src/django/Dockerfile
index 0a8ec79..fefa116 100644
--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -7,6 +7,7 @@ COPY requirements.txt /usr/local/src/
 RUN set -ex \
     && buildDeps=" \
     build-essential \
+    git \
     " \
     && apt-get update && apt-get install -y $buildDeps --no-install-recommends \
     && pip install --no-cache-dir -r requirements.txt \
diff --git a/src/django/requirements.txt b/src/django/requirements.txt
index 60b8160..db1e302 100644
--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -4,7 +4,7 @@ coreapi==2.3.3
 dedupe==1.9.4
 defusedxml==0.6.0
 django-amazon-ses==2.0.0
-django-ecsmanage==1.0.1
+git+https://github.com/azavea/django-ecsmanage.git@feature/jrb/cant-pass-arguments#egg=django-ecsmanage
 django-extensions==2.1.4
 django-jsonview==1.2.0
 django-rest-auth[with_social]==0.9.3
```
- Run `./scripts/update`
- Run `./scripts/manage ecsmanage migrate --noinput`
- See that ecsmanage passed along the `--noinput` argument:
![image](https://user-images.githubusercontent.com/1774125/60985232-1b547b80-a30b-11e9-9e78-003bd1a33abb.png)
- Run `./scripts/manage/ecsmanage showmigrations --hello --whatsup`
- See that this fails (as it should):
![image](https://user-images.githubusercontent.com/1774125/60985389-69697f00-a30b-11e9-9b1e-707e56bc87ce.png)
