### PR TITLE
Connect Actions badge to default branch status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-ecsmanage
 ================
 
-.. image:: https://github.com/azavea/django-ecsmanage/workflows/CI/badge.svg
+.. image:: https://github.com/azavea/django-ecsmanage/workflows/CI/badge.svg?branch=develop
     :target: https://github.com/azavea/django-ecsmanage/actions?query=workflow%3ACI
 
 A Django app that provides a management command allowing you to run any


### PR DESCRIPTION
## Overview

Ensures that the badge will only reflect the build status for the default branch. I've also turned the badge into a link to the workflow page.