### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8"]
     steps:
       - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove support for end-of-life Python 2.7 and 3.4 [#16](https://github.com/azavea/django-ecsmanage/pull/16)
+- Remove support for end-of-life Python 3.5 [#25](https://github.com/azavea/django-ecsmanage/pull/25)
 - Remove support for end-of-life Django 2.0 and 2.1 [#16](https://github.com/azavea/django-ecsmanage/pull/16)
 - Remove support for end-of-life Django 1.11 [#22](https://github.com/azavea/django-ecsmanage/pull/22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for Django 3.x and Python 3.8. No actual code changes were required [#14])(https://github.com/azavea/django-ecsmanage/pull/14)
+- Add support for Django 3.1 and Black source code formatting [#25](https://github.com/azavea/django-ecsmanage/pull/25)
 
 ### Removed
 

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Azavea Inc.
+   Copyright 2020 Azavea Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ Developing
 ----------
 
 Local development is managed with Python virtual environments. Make sure
-that you have Python 3.5+ and pip installed before starting.
+that you have Python 3.6+ and pip installed before starting.
 
 Install the development package in a virtual environment:
 

--- a/ecsmanage/management/commands/ecsmanage.py
+++ b/ecsmanage/management/commands/ecsmanage.py
@@ -1,5 +1,3 @@
-# -*- coding: future_fstrings -*-
-
 import boto3
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings

--- a/scripts/test
+++ b/scripts/test
@@ -28,7 +28,7 @@ function run_linters() {
     # Lint Python scripts.
     ./.venv/bin/flake8 --exclude "*.pyc,.eggs,.venv"
     if command -v ./.venv/bin/black > /dev/null; then
-        ./.venv/bin/black --check --diff --target-version py36 .
+        ./.venv/bin/black --check --diff .
     fi
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ classifiers =
     Framework :: Django
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -24,7 +23,7 @@ classifiers =
 [options]
 include_package_data = True
 packages = find:
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     Django >=2.2
     boto3 >=1.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ python_requires = >=3.6
 install_requires =
     Django >=2.2
     boto3 >=1.9.0
-    future-fstrings >=1.0.0
 setup_requires =
     setuptools_scm ==3.*
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,9 @@ commands =
     check-manifest --ignore tox.ini
     {envpython} setup.py check -m -r -s
     flake8 .
+    black --check --diff .
 skip_install = true
 
 [flake8]
 max-line-length = 88
+extend-ignore = E203, W503

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ deps =
     check-manifest
     flake8
     readme_renderer
-    future-fstrings >=1.0.0
 commands =
     check-manifest --ignore tox.ini
     {envpython} setup.py check -m -r -s

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 envlist =
     lint
-    py{35,36,37,38}-django22
+    py{36,37,38}-django22
     py{36,37,38}-django30
     py{36,37,38}-djangomaster
 
 [gh-actions]
 python =
-    3.5: py35, lint
-    3.6: py36
+    3.6: py36, lint
     3.7: py37
     3.8: py38
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     lint
     py{36,37,38}-django22
     py{36,37,38}-django30
+    py{36,37,38}-django31
     py{36,37,38}-djangomaster
 
 [gh-actions]
@@ -16,6 +17,7 @@ passenv = PYTHONPATH DJANGO_SETTINGS_MODULE
 deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 commands =
     django-admin test --noinput

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands =
 
 [testenv:lint]
 deps =
+    black
     check-manifest
     flake8
     readme_renderer


### PR DESCRIPTION
## Overview

Drop support for Python 3.5 since it's almost end-of-life. Remove [`future-fstrings`](https://pypi.org/project/future-fstrings/) as a dependency since it's only required by Python 3.5. Add `black` to check code formatting during linting.

Closes #18, closes #13, closes #17 

## Testing Instructions

 * Confirm that the [CI workflow](https://github.com/azavea/django-ecsmanage/actions/runs/197766243) passes.