### PR TITLE
Add support for supplying Fargate platform version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for Django 3.x and Python 3.8. No actual code changes were required [#14](https://github.com/azavea/django-ecsmanage/pull/14)
 - Add support for Django 3.1 and Black source code formatting [#25](https://github.com/azavea/django-ecsmanage/pull/25)
+- Add support for supplying Fargate platform version [#26](https://github.com/azavea/django-ecsmanage/pull/26)
 
 ### Removed
 

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,7 @@ environment. For example:
            'TASK_DEFINITION_NAME': 'StagingAppCLI',
            'CLUSTER_NAME': 'ecsStagingCluster',
            'LAUNCH_TYPE': 'FARGATE',
+           'PLATFORM_VERSION': '1.4.0',
            'SECURITY_GROUP_TAGS': {
                'Name': 'sgAppEcsService',
                'Environment': 'Staging',
@@ -128,27 +129,29 @@ AWS Resources
 The following environment configuration keys help the management command locate
 the appropriate AWS resources for your cluster:
 
-+--------------------------+-----------------------------------------------------+---------------+
-| Key                      | Description                                         | Default       |
-|                          |                                                     |               |
-|                          |                                                     |               |
-|                          |                                                     |               |
-+==========================+=====================================================+===============+
-| ``TASK_DEFINITION_NAME`` | The name of your ECS task definition. The command   |               |
-|                          | will automatically retrieve the latest definition.  |               |
-+--------------------------+-----------------------------------------------------+---------------+
-| ``CLUSTER_NAME``         | The name of your ECS cluster.                       |               |
-+--------------------------+-----------------------------------------------------+---------------+
-| ``SECURITY_GROUP_TAGS``  | A dictionary of tags to use to identify a security  |               |
-|                          | group for your task.                                |               |
-+--------------------------+-----------------------------------------------------+---------------+
-| ``SUBNET_TAGS``          | A dictionary of tags to use to identify a subnet    |               |
-|                          | for your task.                                      |               |
-+--------------------------+-----------------------------------------------------+---------------+
-| ``LAUNCH_TYPE``          | The ECS launch type for your task.                  | ``FARGATE``   |
-+--------------------------+-----------------------------------------------------+---------------+
-| ``AWS_REGION``           | The AWS region to run your task.                    | ``us-east-1`` |
-+--------------------------+-----------------------------------------------------+---------------+
++--------------------------+------------------------------------------------------------------+---------------+
+|           Key            |                           Description                            |    Default    |
+|                          |                                                                  |               |
+|                          |                                                                  |               |
+|                          |                                                                  |               |
++==========================+==================================================================+===============+
+| ``TASK_DEFINITION_NAME`` | The name of your ECS task definition. The command                |               |
+|                          | will automatically retrieve the latest definition.               |               |
++--------------------------+------------------------------------------------------------------+---------------+
+| ``CLUSTER_NAME``         | The name of your ECS cluster.                                    |               |
++--------------------------+------------------------------------------------------------------+---------------+
+| ``SECURITY_GROUP_TAGS``  | A dictionary of tags to use to identify a security               |               |
+|                          | group for your task.                                             |               |
++--------------------------+------------------------------------------------------------------+---------------+
+| ``SUBNET_TAGS``          | A dictionary of tags to use to identify a subnet                 |               |
+|                          | for your task.                                                   |               |
++--------------------------+------------------------------------------------------------------+---------------+
+| ``LAUNCH_TYPE``          | The ECS launch type for your task.                               | ``FARGATE``   |
++--------------------------+------------------------------------------------------------------+---------------+
+| ``PLATFORM_VERSION``     | The Fargate platform version, if ``LAUNCH_TYPE`` is ``FARGATE``. | ``LATEST``    |
++--------------------------+------------------------------------------------------------------+---------------+
+| ``AWS_REGION``           | The AWS region to run your task.                                 | ``us-east-1`` |
++--------------------------+------------------------------------------------------------------+---------------+
 
 Developing
 ----------

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
 from setuptools import setup
 
-setup(use_scm_version=True,)
+setup(
+    use_scm_version=True,
+)


### PR DESCRIPTION
## Overview

Pass through the `platformVersion` keyword argument when the configured `launchType` is `FARGATE`. In addition, default `platformVersion` to `LATEST`.

Closes #19 

### Demo

![image](https://user-images.githubusercontent.com/43639/95661985-a9687480-0b01-11eb-88bb-121aa982fd5c.png)

## Testing Instructions

See: https://github.com/open-apparel-registry/open-apparel-registry/pull/1129