### PR TITLE
Add support for overriding Django container name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for Django 3.x and Python 3.8. No actual code changes were required [#14](https://github.com/azavea/django-ecsmanage/pull/14)
 - Add support for Django 3.1 and Black source code formatting [#25](https://github.com/azavea/django-ecsmanage/pull/25)
 - Add support for supplying Fargate platform version [#26](https://github.com/azavea/django-ecsmanage/pull/26)
+- Add support for overriding Django container name [#27](https://github.com/azavea/django-ecsmanage/pull/27)
 
 ### Removed
 

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ environment. For example:
    ECSMANAGE_ENVIRONMENTS = {
        'default': {
            'TASK_DEFINITION_NAME': 'StagingAppCLI',
+           'CONTAINER_NAME': 'django',
            'CLUSTER_NAME': 'ecsStagingCluster',
            'LAUNCH_TYPE': 'FARGATE',
            'PLATFORM_VERSION': '1.4.0',
@@ -137,6 +138,8 @@ the appropriate AWS resources for your cluster:
 +==========================+==================================================================+===============+
 | ``TASK_DEFINITION_NAME`` | The name of your ECS task definition. The command                |               |
 |                          | will automatically retrieve the latest definition.               |               |
++--------------------------+------------------------------------------------------------------+---------------+
+| ``CONTAINER_NAME``       | The name of the Django container in your ECS task definition.    | ``django``    |
 +--------------------------+------------------------------------------------------------------+---------------+
 | ``CLUSTER_NAME``         | The name of your ECS cluster.                                    |               |
 +--------------------------+------------------------------------------------------------------+---------------+

--- a/ecsmanage/management/commands/ecsmanage.py
+++ b/ecsmanage/management/commands/ecsmanage.py
@@ -78,6 +78,7 @@ class Command(BaseCommand):
 
         config = {
             "TASK_DEFINITION_NAME": "",
+            "CONTAINER_NAME": "django",
             "CLUSTER_NAME": "",
             "SECURITY_GROUP_TAGS": "",
             "SUBNET_TAGS": "",
@@ -165,8 +166,6 @@ class Command(BaseCommand):
         Run a task for a given task definition ARN using the given security
         group and subnets, and return the task ID.
         """
-        overrides = {"containerOverrides": [{"name": "django", "command": cmd}]}
-
         task_def = self.ecs_client.describe_task_definition(
             taskDefinition=task_def_arn
         )["taskDefinition"]
@@ -174,7 +173,11 @@ class Command(BaseCommand):
         kwargs = {
             "cluster": config["CLUSTER_NAME"],
             "taskDefinition": task_def_arn,
-            "overrides": overrides,
+            "overrides": {
+                "containerOverrides": [
+                    {"name": config["CONTAINER_NAME"], "command": cmd}
+                ]
+            },
             "count": 1,
             "launchType": config["LAUNCH_TYPE"],
         }


### PR DESCRIPTION
## Overview

Allow users to override the previously hard-coded name of the Django enabled container inside of the provided task definition.

Closes #21 

### Demo

When the container name is overwritten to a container name that does not exist, the AWS ECS API returns an error:

```
Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.7/site-packages/ecsmanage/management/commands/ecsmanage.py", line 48, in handle
    task_id = self.run_task(config, task_def_arn, security_group_id, subnet_id, cmd)
  File "/usr/local/lib/python3.7/site-packages/ecsmanage/management/commands/ecsmanage.py", line 199, in run_task
    task = self.parse_response(self.ecs_client.run_task(**kwargs), "tasks", 0)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 661, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidParameterException: An error occurred (InvalidParameterException) when calling the RunTask operation: Override for container named test is not a container in the TaskDefinition.
```

## Testing Instructions

See: https://github.com/open-apparel-registry/open-apparel-registry/pull/1129