### PR TITLE
Add ASSIGN_PUBLIC_IP configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add ASSIGN_PUBLIC_IP configuration option [#28](https://github.com/azavea/django-ecsmanage/pull/28)
 
 ## [2.0.0] - 2020-10-13
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ environment. For example:
                'Environment': 'Staging',
                'Project': 'ProjectName'
            },
+           'ASSIGN_PUBLIC_IP': 'DISABLED',
            'AWS_REGION': 'us-east-1',
        },
    }
@@ -148,6 +149,9 @@ the appropriate AWS resources for your cluster:
 +--------------------------+------------------------------------------------------------------+---------------+
 | ``SUBNET_TAGS``          | A dictionary of tags to use to identify a subnet                 |               |
 |                          | for your task.                                                   |               |
++--------------------------+------------------------------------------------------------------+---------------+
+| ``ASSIGN_PUBLIC_IP``     | Whether to automatically assign a public IP address to your      | ``DISABLED``  |
+|                          | task. Can be ``ENABLED`` or ``DISABLED``.                        |               |
 +--------------------------+------------------------------------------------------------------+---------------+
 | ``LAUNCH_TYPE``          | The ECS launch type for your task.                               | ``FARGATE``   |
 +--------------------------+------------------------------------------------------------------+---------------+

--- a/ecsmanage/management/commands/ecsmanage.py
+++ b/ecsmanage/management/commands/ecsmanage.py
@@ -82,6 +82,7 @@ class Command(BaseCommand):
             "CLUSTER_NAME": "",
             "SECURITY_GROUP_TAGS": "",
             "SUBNET_TAGS": "",
+            "ASSIGN_PUBLIC_IP": "DISABLED",
             "LAUNCH_TYPE": "FARGATE",
             "PLATFORM_VERSION": "LATEST",
             "AWS_REGION": "us-east-1",
@@ -189,6 +190,7 @@ class Command(BaseCommand):
                 "awsvpcConfiguration": {
                     "subnets": [subnet_id],
                     "securityGroups": [security_group_id],
+                    "assignPublicIp": config["ASSIGN_PUBLIC_IP"],
                 }
             }
 


### PR DESCRIPTION
## Overview

Adds a configuration option for `assignPublicIp` in the `awsvpcConfiguration` block. Setting the `ASSIGN_PUBLIC_IP` config option to `ENABLED` will result in a public IP address automatically being assigned to the new task. This new setting defaults to `DISABLED`, which matches current behavior.

Closes #23 

### Notes

This should result in a minor version bump to the next release.

## Testing Instructions

- Clone https://github.com/open-apparel-registry/open-apparel-registry
- Apply this diff:
```diff
diff --git a/src/django/Dockerfile b/src/django/Dockerfile
index ffa07e5..c342cdb 100644
--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -7,6 +7,7 @@ COPY requirements.txt /usr/local/src/
 RUN set -ex \
     && buildDeps=" \
     build-essential \
+    git \
     " \
     && deps=" \
     postgresql-client-12 \
diff --git a/src/django/oar/settings.py b/src/django/oar/settings.py
index 6674642..6461b52 100644
--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -315,6 +315,7 @@ ECSMANAGE_ENVIRONMENTS = {
             'Environment': 'Staging',
             'Project': 'OpenApparelRegistry'
         },
+        'ASSIGN_PUBLIC_IP': 'ENABLED',
         'AWS_REGION': 'eu-west-1',
     },
     'production': {
diff --git a/src/django/requirements.txt b/src/django/requirements.txt
index dae1c40..f22e0db 100644
--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -4,7 +4,7 @@ coreapi==2.3.3
 dedupe==1.9.4
 defusedxml==0.6.0
 django-amazon-ses==2.1.1
-django-ecsmanage==2.0.0
+git+https://github.com/azavea/django-ecsmanage.git@feature/cek/assign-public-ip#egg=django-ecsmanage
 django-extensions==2.1.9
 django-jsonview==1.2.0
 django-rest-auth[with_social]==0.9.5
```
- Get a shell in the development VM with `vagrant ssh`
- Run `./scripts/update`
- Run `./scripts/manage ecsmanage migrate help`
- Before the newly provisioning / running task stops, confirm that a public IP address has been assigned:
  <img width="443" alt="Screen Shot 2020-10-27 at 10 58 59 PM" src="https://user-images.githubusercontent.com/3892845/97385424-05741c80-18a8-11eb-881b-93d5c7fb74dd.png">
- Run `git checkout HEAD -- ./src/django/oar/settings.py` to revert the changes to that file and remove the `ASSIGN_PUBLIC_IP` setting.
- Run `./scripts/update`
- Run `./scripts/manage ecsmanage migrate help`
- Before the newly provisioning / running task stops, confirm that no public IP address has been assigned:
  <img width="440" alt="Screen Shot 2020-10-27 at 11 03 32 PM" src="https://user-images.githubusercontent.com/3892845/97385714-a95dc800-18a8-11eb-9f7e-d0912535a73a.png">