### PR TITLE
Fix parsing of ECS task ID from task ARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add ASSIGN_PUBLIC_IP configuration option [#28](https://github.com/azavea/django-ecsmanage/pull/28)
 
+### Fixed
+- Fix parsing of ECS task ID from task ARN [#30](https://github.com/azavea/django-ecsmanage/pull/30)
+
 ## [2.0.0] - 2020-10-13
 ### Added
 - Add support for Django 3.x and Python 3.8; no actual code changes were required [#14](https://github.com/azavea/django-ecsmanage/pull/14)

--- a/ecsmanage/management/commands/ecsmanage.py
+++ b/ecsmanage/management/commands/ecsmanage.py
@@ -200,7 +200,11 @@ class Command(BaseCommand):
 
         task = self.parse_response(self.ecs_client.run_task(**kwargs), "tasks", 0)
 
-        # Parse the ask ARN, since ECS doesn't return the task ID.
-        # Task ARNS look like: arn:aws:ecs:<region>:<aws_account_id>:task/<id>
-        task_id = task["taskArn"].split("/")[1]
+        # Task ARNs have at least two formats:
+        #
+        #  - Old: arn:aws:ecs:region:aws_account_id:task/task-id
+        #  - New: arn:aws:ecs:region:aws_account_id:task/cluster-name/task-id
+        #
+        # See: https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-account-settings.html#ecs-resource-ids  # NOQA
+        task_id = task["taskArn"].split("/")[-1]
         return task_id


### PR DESCRIPTION
## Overview

AWS has undergone a change in the way they format ECS task ARNs. Previously, task IDs looked like:

```
 arn:aws:ecs:region:aws_account_id:task/task-id
```

Now, task IDs can also look like:

```
 arn:aws:ecs:region:aws_account_id:task/cluster-name/task-id
```

To account for both versions, always pull the last element of the ARN split by `/`.

Closes #29 

## Notes

For more detail on the ECS task ID formats, see: https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-account-settings.html#ecs-resource-ids

## Testing Instructions

- From within a project exhibiting the symptoms described in #29, install the version of `django-ecsmanage` represented by the branch associated with this PR

```diff
diff --git a/src/django/Dockerfile b/src/django/Dockerfile
index ffa07e5..5c94fee 100644
--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex \
     build-essential \
     " \
     && deps=" \
+    git \
     postgresql-client-12 \
     " \
     && apt-get update && apt-get install -y $buildDeps $deps --no-install-recommends \
diff --git a/src/django/requirements.txt b/src/django/requirements.txt
index dae1c40..62fb992 100644
--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -4,7 +4,7 @@ coreapi==2.3.3
 dedupe==1.9.4
 defusedxml==0.6.0
 django-amazon-ses==2.1.1
-django-ecsmanage==2.0.0
+git+https://github.com/azavea/django-ecsmanage.git@feature/hmc/fix-cloudwatch-url#egg=django-ecsmanage
 django-extensions==2.1.9
 django-jsonview==1.2.0
 django-rest-auth[with_social]==0.9.5
```

- After rebuilding the `django` container image, execute `django-ecsmanage` and inspect the URL emitted

```console
$ ./scripts/manage ecsmanage showmigrations
```

- **Optional**: If you want to go even further, toggle the old and new ECS **Task** ARN formats for your IAM user via the [ECS account settings](https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settings); test using each to ensure both work

```console
$ ./scripts/manage ecsmanage showmigrations
Starting database_1 ... done
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
arn:aws:ecs:eu-west-1:****:task/fcf6c042-1a6c-427d-9a8d-685b1ce9e3de
Task started! View here:
https://console.aws.amazon.com/ecs/home?region=eu-west-1#/clusters/ecsStagingCluster/tasks/fcf6c042-1a6c-427d-9a8d-685b1ce9e3de/details
$ ./scripts/manage ecsmanage showmigrations
Starting database_1 ... done
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
arn:aws:ecs:eu-west-1:****:task/ecsStagingCluster/7bde6fe343994224bd592c171e6c6a5f
Task started! View here:
https://console.aws.amazon.com/ecs/home?region=eu-west-1#/clusters/ecsStagingCluster/tasks/7bde6fe343994224bd592c171e6c6a5f/details
```

