### PR TITLE
Support default network modes, Update Python and Django Support

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.8", "3.10", "3.12"]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,10 +15,10 @@ jobs:
       matrix:
         python-version: ["3.8", "3.10", "3.12"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add support for Django 3.2, 4.2, 5.0 [#33](https://github.com/azavea/django-ecsmanage/pull/33)
+
 ### Removed
 - Remove support for end-of-life Python 3.6 and 3.7, Django 2.2, 3.0, and 3.1 [#33](https://github.com/azavea/django-ecsmanage/pull/33)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for Django 3.2, 4.2, 5.0 [#33](https://github.com/azavea/django-ecsmanage/pull/33)
 
 ### Changed
+- Support default network modes [#33](https://github.com/azavea/django-ecsmanage/pull/33)
 - Upgrade CI to use newer GitHub Actions for `checkout` and `setup-python` [#33](https://github.com/azavea/django-ecsmanage/pull/33)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- Remove support for end-of-life Python 3.6 and 3.7, Django 2.2, 3.0, and 3.1 [#33](https://github.com/azavea/django-ecsmanage/pull/33)
+
 ## [2.0.1] - 2020-11-24
 ### Added
 - Add ASSIGN_PUBLIC_IP configuration option [#28](https://github.com/azavea/django-ecsmanage/pull/28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for Django 3.2, 4.2, 5.0 [#33](https://github.com/azavea/django-ecsmanage/pull/33)
 
+### Changed
+- Upgrade CI to use newer GitHub Actions for `checkout` and `setup-python` [#33](https://github.com/azavea/django-ecsmanage/pull/33)
+
 ### Removed
 - Remove support for end-of-life Python 3.6 and 3.7, Django 2.2, 3.0, and 3.1 [#33](https://github.com/azavea/django-ecsmanage/pull/33)
 

--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ Developing
 ----------
 
 Local development is managed with Python virtual environments. Make sure
-that you have Python 3.6+ and pip installed before starting.
+that you have Python 3.8+ and pip installed before starting.
 
 Install the development package in a virtual environment:
 

--- a/ecsmanage/management/commands/ecsmanage.py
+++ b/ecsmanage/management/commands/ecsmanage.py
@@ -185,7 +185,7 @@ class Command(BaseCommand):
 
         # Only the awsvpc network mode supports the networkConfiguration
         # input value.
-        if task_def["networkMode"] == "awsvpc":
+        if task_def.get("networkMode") == "awsvpc":
             kwargs["networkConfiguration"] = {
                 "awsvpcConfiguration": {
                     "subnets": [subnet_id],

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,22 +9,16 @@ license = Apache License 2.0
 classifiers =
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 2.2
-    Framework :: Django :: 3.0
-    Framework :: Django :: 3.1
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
 include_package_data = True
 packages = find:
-python_requires = >=3.6
 install_requires =
     Django >=2.2
     boto3 >=1.9.0
@@ -34,4 +28,3 @@ setup_requires =
 [options.extras_require]
 tests =
     flake8 >=3.7.7
-    black; python_version > "3.6"

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,16 +9,22 @@ license = Apache License 2.0
 classifiers =
     Environment :: Web Environment
     Framework :: Django
+    Framework :: Django :: 3.2
+    Framework :: Django :: 4.2
+    Framework :: Django :: 5.0
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.12
 
 [options]
 include_package_data = True
 packages = find:
+python_requires = >=3.8
 install_requires =
     Django >=2.2
     boto3 >=1.9.0
@@ -28,3 +34,4 @@ setup_requires =
 [options.extras_require]
 tests =
     flake8 >=3.7.7
+    black; python_version > "3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,14 @@
 [tox]
 envlist =
     lint
-    py{36,37,38}-django22
-    py{36,37,38}-django30
-    py{36,37,38}-django31
-    py{36,37,38}-djangomaster
 
 [gh-actions]
 python =
-    3.6: py36, lint
-    3.7: py37
     3.8: py38
 
 [testenv]
 passenv = PYTHONPATH DJANGO_SETTINGS_MODULE
 deps =
-    django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 commands =
     django-admin test --noinput

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,23 @@
 [tox]
 envlist =
     lint
+    py{38,310,312}-django32
+    py{310,312}-django42
+    py{310,312}-django50
+    py{310,312}-djangomaster
 
 [gh-actions]
 python =
     3.8: py38
+    3.10: py310
+    3.12: py312
 
 [testenv]
 passenv = PYTHONPATH DJANGO_SETTINGS_MODULE
 deps =
+    django32: Django>=3.2,<3.3
+    django42: Django>=4.2,<4.3
+    django50: Django>=5.0,<5.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 commands =
     django-admin test --noinput

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ python =
     3.12: py312
 
 [testenv]
-passenv = PYTHONPATH DJANGO_SETTINGS_MODULE
+passenv = PYTHONPATH,DJANGO_SETTINGS_MODULE
 deps =
     django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3


### PR DESCRIPTION
## Overview

In the case of default network modes, the `networkMode` attribute is not specified in the `describe-task-definition` response. For these cases, we add tolerance for when it isn't specified, defaulting to `None`, and skipping the AWSVPC configuration block.

## BREAKING CHANGE

Also drops support for Django 2.2, 3.0, 3.1, and Python 3.6 and 3.7.

## Testing Instructions

- Check out this branch: https://github.com/azavea/collab-for-children/tree/release/1.0
- Run `./scripts/manage ecsmanage showmigrations`
  - [ ] Ensure it runs correctly