### PR TITLE
Resolve error when task network mode is not awsvpc

### DIFF
--- a/ecsmanage/management/commands/ecsmanage.py
+++ b/ecsmanage/management/commands/ecsmanage.py
@@ -185,7 +185,7 @@ class Command(BaseCommand):
 
         # Only the awsvpc network mode supports the networkConfiguration
         # input value.
-        if task_def["networkMode"] == "awsvpc":
+        if "networkMode" in task_def and task_def["networkMode"] == "awsvpc":
             kwargs["networkConfiguration"] = {
                 "awsvpcConfiguration": {
                     "subnets": [subnet_id],


### PR DESCRIPTION
## Overview

This is a change that Rocky made in 2021 and we've been using the branch in MUB's requirements file ever since.  His commit message:
> When a task's network mode is not awsvpc (e.g., when we're using a traditional ECS cluster), the payload from describe_task_definition doesn't have the networkMode key.

I don't know for sure that that's even still true, though my guess would be that the API for old-style ECS clusters hasn't changed.  I also haven't tested this change in any way, except to the extent that it's been in use on MUB.

But given that it seems mathematically impossible that substituting "check for the key, then look it up" for "just look it up" would cause problems, that seems OK to me.
